### PR TITLE
Fix compilation on Darwin with go1.10

### DIFF
--- a/root_cgo_darwin.go
+++ b/root_cgo_darwin.go
@@ -66,7 +66,7 @@ import "unsafe"
 func initSystemRoots() {
 	roots := NewCertPool()
 
-	var data C.CFDataRef = nil
+	var data C.CFDataRef = 0
 	err := C.OurFetchPEMRoots(&data)
 	if err == -1 {
 		return

--- a/root_go110_cgo_darwin.go
+++ b/root_go110_cgo_darwin.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build cgo,!arm,!arm64,!ios
+// +build go1.10,cgo,!arm,!arm64,!ios
 
 package systemcerts
 

--- a/root_pre_go110_cgo_darwin.go
+++ b/root_pre_go110_cgo_darwin.go
@@ -1,0 +1,79 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.10,cgo,!arm,!arm64,!ios
+
+package systemcerts
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+// FetchPEMRoots fetches the system's list of trusted X.509 root certificates.
+//
+// On success it returns 0 and fills pemRoots with a CFDataRef that contains the extracted root
+// certificates of the system. On failure, the function returns -1.
+//
+// Note: The CFDataRef returned in pemRoots must be released (using CFRelease) after
+// we've consumed its content.
+int OurFetchPEMRoots(CFDataRef *pemRoots) {
+	if (pemRoots == NULL) {
+		return -1;
+	}
+
+	CFArrayRef certs = NULL;
+	OSStatus err = SecTrustCopyAnchorCertificates(&certs);
+	if (err != noErr) {
+		return -1;
+	}
+
+	CFMutableDataRef combinedData = CFDataCreateMutable(kCFAllocatorDefault, 0);
+	int i, ncerts = CFArrayGetCount(certs);
+	for (i = 0; i < ncerts; i++) {
+		CFDataRef data = NULL;
+		SecCertificateRef cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+		if (cert == NULL) {
+			continue;
+		}
+
+		// Note: SecKeychainItemExport is deprecated as of 10.7 in favor of SecItemExport.
+		// Once we support weak imports via cgo we should prefer that, and fall back to this
+		// for older systems.
+		err = SecKeychainItemExport(cert, kSecFormatX509Cert, kSecItemPemArmour, NULL, &data);
+		if (err != noErr) {
+			continue;
+		}
+
+		if (data != NULL) {
+			CFDataAppendBytes(combinedData, CFDataGetBytePtr(data), CFDataGetLength(data));
+			CFRelease(data);
+		}
+	}
+
+	CFRelease(certs);
+
+	*pemRoots = combinedData;
+	return 0;
+}
+*/
+import "C"
+import "unsafe"
+
+func initSystemRoots() {
+	roots := NewCertPool()
+
+	var data C.CFDataRef = nil
+	err := C.OurFetchPEMRoots(&data)
+	if err == -1 {
+		return
+	}
+
+	defer C.CFRelease(C.CFTypeRef(data))
+	buf := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(data)), C.int(C.CFDataGetLength(data)))
+	roots.AppendCertsFromPEM(buf)
+	systemRoots = roots
+}


### PR DESCRIPTION
From [Go 1.10 Release Notes: cgo](https://golang.org/doc/go1.10#cgo) (emphasis mine):

> Cgo now translates some C types that would normally map to a pointer type in Go, to a uintptr instead. These types include the CFTypeRef hierarchy in Darwin's CoreFoundation framework and the jobject hierarchy in Java's JNI interface.
> 
> These types must be uintptr on the Go side because they would otherwise confuse the Go garbage collector; they are sometimes not really pointers but data structures encoded in a pointer-sized integer. Pointers to Go memory must not be stored in these uintptr values.
> 
> Because of this change, **values of the affected types need to be zero-initialized with the constant 0 instead of the constant nil**. Go 1.10 provides gofix modules to help with that rewrite: